### PR TITLE
Updated pdfjs reference to correctly identify objects

### DIFF
--- a/vendor/assets/javascripts/pdfjs/web/viewer.js
+++ b/vendor/assets/javascripts/pdfjs/web/viewer.js
@@ -9164,7 +9164,7 @@ var PDFLinkService = /*#__PURE__*/function () {
       var destRef = explicitDest[0];
       var pageNumber;
 
-      if (destRef instanceof Object) {
+      if (typeof destRef === "object" && destRef !== null) {
         pageNumber = this._cachedPageNumber(destRef);
 
         if (pageNumber === null) {


### PR DESCRIPTION
resolves #8274
Though we don't expose outlines in our pdfjs viewer, some documents contain internal links to pages within their own documents which works as an outline. This resolves a bug where people clicking those links were not taken to the expected pages 