### PR TITLE
Allow installing in Rails 6 and 7

### DIFF
--- a/pdfjs.gemspec
+++ b/pdfjs.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 5.0"
+  s.add_dependency 'rails', '>= 5.0', '< 8'
 end


### PR DESCRIPTION
This bumps the Rails version constraint in the runtime dependencies to allow installing in Rails 5, 6, and 7 (but not 8 yet).

I've confirmed the `Rails::Engine` API we're using here is [still supported in Rails 7.1](https://guides.rubyonrails.org/v7.1/engines.html#separate-assets-and-precompiling).